### PR TITLE
fix: resolve numpy version incompatibility

### DIFF
--- a/deploy-ml-model/requirements.txt
+++ b/deploy-ml-model/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.18.3
 scikit-learn==1.2.2
 joblib==1.3.2
 pandas==2.1.0
+numpy==1.26.4


### PR DESCRIPTION
The latest `numpy` version is not compatible with the given `pandas` version. Degraded the `numpy` version to `1.26.4`