### PR TITLE
Import get_access_token from auth_context

### DIFF
--- a/calculator-oauth-mcp-server/calculator.py
+++ b/calculator-oauth-mcp-server/calculator.py
@@ -1,5 +1,6 @@
 from fastmcp import FastMCP, Context
 import os
+from mcp.server.auth.middleware.auth_context import get_access_token
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from dotenv import load_dotenv
 from starlette.responses import RedirectResponse


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single import added to wire `get_access_token` into `calculator.py`; minimal behavioral risk aside from potential runtime import/path issues if the dependency isn’t available.
> 
> **Overview**
> Updates `calculator-oauth-mcp-server/calculator.py` to import `get_access_token` from `mcp.server.auth.middleware.auth_context`, enabling `get_me` to read JWT claims from the auth context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b61c36d03ec6b2ce28a9b8ee7ad7c22ddf1bfb9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->