### PR TITLE
Fix rag-app chart: invalid tfy-secret:// FQN used as K8s Secret name

### DIFF
--- a/rag-onboarding-with-helm/README.md
+++ b/rag-onboarding-with-helm/README.md
@@ -82,8 +82,17 @@ Edit `deploy/rag-app.truefoundry.yaml` and fill in:
 
 - `workspace_fqn` — same workspace as Step 1
 - `values.image.repository` / `tag` — the image from Step 2
-- `values.config.truefoundry.llmGatewayBaseUrl` / `apiKey`
+- `values.config.truefoundry.llmGatewayBaseUrl`
 - `values.config.llmModel` / `embeddingModel` / `embeddingDimensions`
+- the `kustomize.additions` Secret manifest — replace the `tfy-secret://...`
+  FQN with your own TrueFoundry secret FQN and set the Secret's `namespace`
+  to your workspace's namespace
+
+> **Note:** `tfy-secret://` FQNs are only resolved inside Kubernetes Secret
+> manifests added via `kustomize.additions` (using `stringData`). They are
+> **not** resolved inside Helm `values`, so never put an FQN in
+> `values.config.truefoundry.apiKey` or `existingSecret` — the latter must be
+> the name of a real Kubernetes Secret.
 
 ```bash
 tfy apply -f deploy/rag-app.truefoundry.yaml

--- a/rag-onboarding-with-helm/charts/rag-app/values.yaml
+++ b/rag-onboarding-with-helm/charts/rag-app/values.yaml
@@ -29,9 +29,13 @@ config:
     # e.g. https://<your-org>.truefoundry.cloud/api/llm/api/inference/openai
     llmGatewayBaseUrl: "https://gateway.truefoundry.ai"
     # TrueFoundry API key; ignored if existingSecret is set
-    apiKey: "tfy-secret://tfy-eo:chintan-secrets:TFY-API-KEY"
-    # Existing secret with key TFY_API_KEY
-    existingSecret: "tfy-secret://tfy-eo:chintan-secrets:TFY-API-KEY"
+    apiKey: ""
+    # Name of an existing Kubernetes Secret with key TFY_API_KEY.
+    # Must be a valid K8s Secret name (RFC 1123), NOT a tfy-secret:// FQN.
+    # When deploying via TrueFoundry, create the Secret with kustomize
+    # additions (see deploy/rag-app.truefoundry.yaml) — tfy-secret:// FQNs
+    # are only resolved there, not inside Helm values.
+    existingSecret: ""
   llmModel: openai-main/gpt-4o-mini
   embeddingModel: openai-main/text-embedding-3-small
   embeddingDimensions: 1536

--- a/rag-onboarding-with-helm/deploy/rag-app.truefoundry.yaml
+++ b/rag-onboarding-with-helm/deploy/rag-app.truefoundry.yaml
@@ -29,11 +29,27 @@ values:
       apiPrefix: ""
     truefoundry:
       llmGatewayBaseUrl: https://gateway.truefoundry.ai
-      apiKey: tfy-secret://tfy-eo:chintan-secrets:TFY-API-KEY
+      # tfy-secret:// FQNs are NOT resolved inside Helm values — they are only
+      # resolved in Kubernetes Secret manifests added via kustomize.additions
+      # (see below). Point existingSecret at that Secret instead.
+      apiKey: ""
+      existingSecret: rag-app-tfy-creds
       host: https://tfy-eo.truefoundry.cloud
     llmModel: openai-main/gpt-4o-mini
     embeddingModel: openai-main/text-embedding-3-small
     embeddingDimensions: 1536
     collectionName: documents
     localFakeLlm: false
+kustomize:
+  additions:
+    # TrueFoundry resolves the tfy-secret:// FQN when applying this manifest,
+    # so the real API key lands in the K8s Secret referenced above.
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: rag-app-tfy-creds
+        namespace: chintan-onboarding-ws
+      type: Opaque
+      stringData:
+        TFY_API_KEY: tfy-secret://tfy-eo:chintan-secrets:TFY-API-KEY
 workspace_fqn: tfy-ea-dev-eo-az:chintan-onboarding-ws


### PR DESCRIPTION
## Summary

Deploying the `rag-app` chart currently fails with:

```
Deployment.apps "ps-rag" is invalid: spec.template.spec.containers[0].env[4].valueFrom.secretKeyRef.name: Invalid value: "tfy-secret://tfy-eo:chintan-secrets:TFY-API-KEY": a lowercase RFC 1123 subdomain must consist of ...
```

Root cause: `charts/rag-app/values.yaml` sets `config.truefoundry.existingSecret` (and `apiKey`) to a `tfy-secret://` FQN. The deployment template feeds `existingSecret` straight into `secretKeyRef.name`, which must be a real Kubernetes Secret name. TrueFoundry only resolves `tfy-secret://` FQNs inside Kubernetes Secret manifests added via `kustomize.additions` ([docs](https://www.truefoundry.com/docs/deploy-helm-charts#using-secrets-recommended)) — never inside Helm `values`.

Changes:

- `charts/rag-app/values.yaml`: reset `config.truefoundry.apiKey` / `existingSecret` defaults to `""` and document that `existingSecret` must be a valid K8s Secret name, not an FQN.
- `deploy/rag-app.truefoundry.yaml`: create the K8s Secret `rag-app-tfy-creds` via `kustomize.additions` (where the FQN *is* resolved) and point `config.truefoundry.existingSecret` at it.
- `README.md`: document the pattern and the FQN-resolution caveat.

`deploy/deploy.py` is untouched — it passes a real key from the environment into `apiKey`, so the chart creates its own Secret and that path still works.

## Test plan

- [x] Both edited YAML files parse cleanly
- [ ] `tfy apply -f deploy/rag-app.truefoundry.yaml` succeeds and the pod gets `TFY_API_KEY` from Secret `rag-app-tfy-creds`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and docs only for the onboarding example; no runtime app logic changes, and deploy.py’s env-based apiKey path is unchanged.
> 
> **Overview**
> Fixes **rag-app** deploy failures caused by putting a `tfy-secret://` FQN in `config.truefoundry.existingSecret`, which Helm passes straight into `secretKeyRef.name` and must be a valid Kubernetes Secret name.
> 
> **Chart defaults** (`values.yaml`): clears `apiKey` and `existingSecret` and documents that FQNs belong only in `kustomize.additions` Secret manifests, not in Helm values.
> 
> **TrueFoundry deploy** (`rag-app.truefoundry.yaml`): adds a `kustomize.additions` Secret (`rag-app-tfy-creds`) whose `stringData.TFY_API_KEY` uses the `tfy-secret://` FQN (resolved on apply), and sets `existingSecret: rag-app-tfy-creds` so the pod reads `TFY_API_KEY` from that Secret.
> 
> **README**: Step 3 now calls out editing the kustomize Secret (FQN + namespace) and the note that `tfy-secret://` is not resolved inside Helm `values`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb71458e260e1347b9d77351ce7f17929afa941a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->